### PR TITLE
design(front): add new blue & increase menu size

### DIFF
--- a/eksae.css
+++ b/eksae.css
@@ -1,5 +1,5 @@
 :root {
-  --color-primary: #0d6efd;
+  --color-primary: #239BD6;
 }
 
 body {
@@ -30,4 +30,30 @@ table td {
   font-weight: bold;
   margin-top: 8px;
   padding: 8px 16px;
+}
+
+a.TopBlue {
+  font-size: 16px !important;
+  background-color: var(--color-primary);
+  color: white;
+  padding: 1rem 1.5rem;
+  border-radius: 5px;
+}
+
+li.TopBlue {
+  list-style-type: none;
+
+}
+
+td.EtatC {
+  background-color: #aadcca;
+  font-weight: bold;
+}
+
+div.modules {
+  padding: 2rem 0;
+}
+
+a.modules__module,  .modules__module--selected, .modules__accueil {
+  font-size: 16px !important;
 }


### PR DESCRIPTION
## :pancakes: Problème
Le menu ressemble à un breadcrumb, les textes sont illisibles, le vert de validation des congés pique les yeux.

## :bacon: Proposition
Elargissement du menu, de ses textes. Changement de la couleur de validation des congés pour un vert moins agressif, et ajout de graisse sur la lettre C (pour Congé).
En même temps, proposition de changement du bleu primary

## 🧃 Remarques
RAS (mais c'est rigolo)

## :yum: Pour tester
Tester directement le style avec l'extension Stylus sur eksae et voir à quoi ça ressemble.